### PR TITLE
feat: Integrate OpenFeign client for service-to-service communication

### DIFF
--- a/src/main/java/com/question/Controller/QuestionController.java
+++ b/src/main/java/com/question/Controller/QuestionController.java
@@ -30,4 +30,10 @@ public class QuestionController {
         return this.questionService.addQuestion(question);
     }
 
+    //  For Question Client to implement Feign
+    @GetMapping("/quiz/{quizId}")
+    public List<Question> getByQuizId(@PathVariable Integer quizId){
+        return this.questionService.getQuizById(quizId);
+    }
+
 }

--- a/src/main/java/com/question/Repository/QuestionRepository.java
+++ b/src/main/java/com/question/Repository/QuestionRepository.java
@@ -4,6 +4,10 @@ import com.question.Entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface QuestionRepository extends JpaRepository<Question,Integer> {
+
+    List<Question> findByQuizId(Integer quizId);
 }

--- a/src/main/java/com/question/Service/QuestionService.java
+++ b/src/main/java/com/question/Service/QuestionService.java
@@ -11,4 +11,7 @@ public interface QuestionService {
     Question getQuestionById(Integer questionId);
     Question addQuestion(Question question);
 
+//  For Question Client to implement feign
+    List<Question> getQuizById(Integer quizId);
+
 }

--- a/src/main/java/com/question/ServiceImpl/QuestionServiceImpl.java
+++ b/src/main/java/com/question/ServiceImpl/QuestionServiceImpl.java
@@ -26,7 +26,13 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Override
     public Question addQuestion(Question question) {
-        System.out.print("Question:: "+question.getQuizId());
         return questionRepository.save(question);
     }
+
+    @Override
+    public List<Question> getQuizById(Integer quizId) {
+        return questionRepository.findByQuizId(quizId);
+    }
+
+
 }


### PR DESCRIPTION
feat: Integrate OpenFeign client for service-to-service communication

- Added OpenFeign dependencies in pom.xml
- Created one API which return the Question list based on Question Id.

# Improves modularity and simplifies HTTP client logic
OpenFeign is a declarative REST client in Java used to simplify HTTP communication between microservices. Instead of writing boilerplate code with RestTemplate or WebClient, I can define an interface and annotate it with Feign annotations like @FeignClient. Spring Cloud then automatically generates the implementation at runtime. It supports features like load balancing, fallback handling, and request logging. I’ve used it in projects to make service-to-service calls cleaner, more readable, and easier to maintain.